### PR TITLE
Make bet impervious to user spelling/capitalization errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -1434,13 +1434,13 @@ client.on("messageCreate", async (message) => {
     const coinFlip = Math.random() > 0.5 ? "heads" : "tails";
 
     const betAmount = parseInt(args[0]);
-    const bet = args[1];
+    const bet = args[1].toLowerCase();
 
     if (!betAmount || betAmount > 10000 || betAmount < 0) {
       return message.channel.send("You must put in a valid amount to bet");
     }
 
-    if (!bet) {
+    if (!bet||!["heads","tails"].includes(bet)) {
       return message.channel.send("You must either bet heads or tails");
     }
 


### PR DESCRIPTION
Make bet case-insensitive, and not run the bet if the user doesn't input heads or tails - such as due to a typo